### PR TITLE
fix: update images parsed bug

### DIFF
--- a/src/editor/uix/extensions/editing-modes/suggestion-mode.ts
+++ b/src/editor/uix/extensions/editing-modes/suggestion-mode.ts
@@ -117,13 +117,13 @@ function applySuggestion(tr: Transaction, settings: PluginSettings): Transaction
 		const is_recognized_edit_operation = tr.isUserEvent("input") || tr.isUserEvent("paste") ||
 			tr.isUserEvent("delete");
 
-		// ISSUE: Pasting an image yields no userEvent that could be used to determine the type, so the
-		//      operation type needs to be determined via the changed ranges. However, a change of the state
-		//      *will* result in the new transaction being filtered through the suggestion mode filter again (recursion)
-		// TODO: Currently, a only transactions with valid userEvents editevents considered
-		//       Somehow, someway, image pastes need to get an userevent attached (monkey-around insertFiles?)
-		// TODO: Dragging and dropping a selection also doesn't seem to fire a userEvent
-		if (!is_recognized_edit_operation)
+		// Obsidian's insertFiles() (used for image pastes and drag-drop) dispatches a transaction
+		// with no userEvent. Detect these as pure insertions: doc changed, nothing deleted, text added.
+		const is_unlabeled_insertion = !is_recognized_edit_operation &&
+			changed_ranges.length > 0 &&
+			changed_ranges.every(r => r.inserted.length > 0 && r.offset.removed === 0);
+
+		if (!is_recognized_edit_operation && !is_unlabeled_insertion)
 			return tr;
 
 		const ranges = tr.startState.field(rangeParser).ranges;
@@ -196,7 +196,7 @@ function applySuggestion(tr: Transaction, settings: PluginSettings): Transaction
 		if (!changes.length)
 			return tr;
 
-        const forwardedEvent = deriveUserEvent(tr);
+        const forwardedEvent = deriveUserEvent(tr) ?? (is_unlabeled_insertion ? "input" : undefined);
         return tr.startState.update({
 			changes,
 			selection: EditorSelection.create(selections),


### PR DESCRIPTION
---
 # Summary

 This PR fixes image (and drag-dropped resource) pastes in suggestion mode not being wrapped in an Addition annotation.

 - Image paste annotation missing — Pasting an image in suggestion mode now wraps the inserted link in
 {++![[image.png]]++} as expected (fixes [issue #45 ])
 - Drag-drop annotation missing — Dragging a file into the editor in suggestion mode also now correctly produces an
 Addition annotation (addressed the existing TODO in the source)

 # Changes

 ## Image / Resource Paste Fix

 Obsidian's internal insertFiles() method (called when pasting or dropping image files) dispatches a CodeMirror
 transaction with no userEvent annotation attached. The transaction filter in suggestion-mode.ts checked only for
 "input", "paste", and "delete" events, so these unlabeled transactions hit an early return and were passed through
 unwrapped.

 Solution: Added an is_unlabeled_insertion check after the is_recognized_edit_operation check. A transaction is treated
 as an unlabeled insertion when:
 - The document changed
 - No recognized userEvent is present
 - Every changed range is a pure addition (text inserted, nothing deleted)

 This covers image pastes, drag-drop, and any other Obsidian-internal insertions without needing to inspect the inserted
 text for specific syntax patterns.

 Also added a forwardedEvent fallback so the replacement transaction is labeled "input", keeping undo/redo history
 consistent.

 File changed: src/editor/uix/extensions/editing-modes/suggestion-mode.ts

 # Testing

 Tested manually in Obsidian sandbox environment 1.12.7 with:

 - Paste an image from clipboard in suggestion mode → link appears as {++![[image.png]]++}
 - Drag an image from the file explorer into the editor in suggestion mode → same Addition annotation
 - Normal typing and text paste in suggestion mode → unchanged behavior
 - Deletion and substitution in suggestion mode → unchanged behavior
 - Undo after image paste → suggestion markup removed cleanly

 ---
 